### PR TITLE
Removing warnings and errors on template debuging

### DIFF
--- a/enterprise-edition/templates/backend/statefulset.yaml
+++ b/enterprise-edition/templates/backend/statefulset.yaml
@@ -90,7 +90,7 @@ spec:
             name: {{ template "name" . }}-backend-env
         volumeMounts:
         {{- if .Values.backend.volumeMounts }}
-        {{- toYaml .Values.backend.volumeMounts . | nindent 8 }}
+        {{- toYaml .Values.backend.volumeMounts | nindent 8 }}
         {{- end }}
         {{- range .Values.backend.secretMounts }}
         - name: {{ .name }}

--- a/enterprise-edition/values.yaml
+++ b/enterprise-edition/values.yaml
@@ -37,7 +37,7 @@ backend:
 
   annotations: {}
 
-  initContainers: {}
+  initContainers: []
 
   affinity: {}
   #  podAntiAffinity:
@@ -116,8 +116,8 @@ backend:
   # schedulerName:
 
   # Custom backend volumes
-  volumes: {}
-  volumeMounts: {}
+  volumes: []
+  volumeMounts: []
 
   persistentVolume:
     ## If true, backend will create/use a Persistent Volume Claim


### PR DESCRIPTION
This pull request closes the following issues : 

- Closes https://github.com/OctoPerf/helm-charts/issues/14
- Closes https://github.com/OctoPerf/helm-charts/issues/12
---

### What this PR Fixes
Mulitple Warning and an error when overriding specific variables : 

- `backend.volumes` 
- `backend.volumeMounts` 
- `backend.initContainers` 


#### Old behavior

```
PS C:\[...]\octoperf-helm-charts> helm template --debug test .\enterprise-edition\ -f ./values-override.yaml > test.txt
install.go:173: [debug] Original chart version: ""
install.go:190: [debug] CHART PATH: C:\[...]\octoperf-helm-charts\enterprise-edition

coalesce.go:200: warning: cannot overwrite table with non table for volumes (map[])
coalesce.go:200: warning: cannot overwrite table with non table for initContainers (map[])
coalesce.go:200: warning: cannot overwrite table with non table for volumeMounts (map[])
coalesce.go:200: warning: cannot overwrite table with non table for volumes (map[])
coalesce.go:200: warning: cannot overwrite table with non table for initContainers (map[])
coalesce.go:200: warning: cannot overwrite table with non table for volumeMounts (map[])
Error: template: enterprise-edition/templates/backend/statefulset.yaml:93:12: executing "enterprise-edition/templates/backend/statefulset.yaml" at <toYaml>: wrong number of args for toYaml: want 1 got 2  
helm.go:81: [debug] template: enterprise-edition/templates/backend/statefulset.yaml:93:12: executing "enterprise-edition/templates/backend/statefulset.yaml" at <toYaml>: wrong number of args for toYaml: want 1 got 2
```

#### New behavior : click to exapand...

```
PS C:\[...]\octoperf-helm-charts> helm template --debug test .\enterprise-edition\ -f ./values-override.yaml > test.txt
install.go:173: [debug] Original chart version: ""
install.go:190: [debug] CHART PATH: C:\[...]\octoperf-helm-charts\enterprise-edition
```
**Warnings and errors removed**



---
Debbuging values used to reproduce the bug : 

<details>
<summary><h4>Click to exapand...</h4></summary>

`helm template --debug test .\enterprise-edition\ -f ./values-override.yaml `

```
#values-override.yaml

backend:
  enabled: true
  volumes:
    - name: dummy-volume-2
      configMap:
        name: dummy-configmap-2
    - name: dummy-volume
      configMap:
        name: dummy-configmap

  volumeMounts:
    - mountPath: /dummy-dir-2
      name: dummy-volume-2
    - mountPath: /dummy-dir
      name: dummy-volume

  initContainers:
    - name: init-container-2
      image: busybox:1.28
      command: ["/bin/sh"]
      args: ["-c", "while true; do echo hello2; sleep 10;done"]
    - name: init-container
      image: busybox:1.28
      command: ["/bin/sh"]
      args: ["-c", "while true; do echo hello; sleep 10;done"]
```


</details>