### PR TITLE
Fix imagePullSecrets in  enterprise-edition-doc deployment.yaml

### DIFF
--- a/enterprise-edition/templates/documentation/deployment.yaml
+++ b/enterprise-edition/templates/documentation/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- range .Values.imagePullSecrets }}
-        - name: {{ . }}
+        - name: {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
     {{- end }}
     {{- if .Values.doc.nodeSelector }}


### PR DESCRIPTION
Installing with Helm will return a wrong value replaced in imagePullSecrets.

Example, a dry-run with helm install like the following: helm install octoperf-ee octoperf/enterprise-edition --dry-run --set 'imagePullSecrets[0].name=artifactory-image-pull-secret'


will return:

# Source: enterprise-edition/templates/documentation/deployment.yaml apiVersion: apps/v1
kind: Deployment
.....
    spec:
      imagePullSecrets:
        - name: map[name:artifactory-image-pull-secret]

The applied change is based on what is done on the other deployment templates.