### PR TITLE
Adding compute resource fileds for front & doc deployments 

### DIFF
--- a/enterprise-edition/templates/documentation/deployment.yaml
+++ b/enterprise-edition/templates/documentation/deployment.yaml
@@ -60,4 +60,6 @@ spec:
         {{- toYaml .Values.doc.readinessProbe | nindent 10 }}
         livenessProbe:
         {{- toYaml .Values.doc.livenessProbe | nindent 10 }}
+        resources:
+        {{- toYaml .Values.doc.resources | nindent 10 }}
 {{- end }}

--- a/enterprise-edition/templates/frontend/deployment.yaml
+++ b/enterprise-edition/templates/frontend/deployment.yaml
@@ -65,9 +65,9 @@ spec:
             mountPath: /usr/share/nginx/html/assets/config-prod.json
             subPath: config-prod.json
         readinessProbe:
-        {{ toYaml .Values.frontend.readinessProbe | nindent 10 }}
+        {{- toYaml .Values.frontend.readinessProbe | nindent 10 }}
         livenessProbe:
-        {{ toYaml .Values.frontend.livenessProbe | nindent 10 }}
+        {{- toYaml .Values.frontend.livenessProbe | nindent 10 }}
         resources:
         {{- toYaml .Values.frontend.resources | nindent 10 }}
 {{- end }}

--- a/enterprise-edition/templates/frontend/deployment.yaml
+++ b/enterprise-edition/templates/frontend/deployment.yaml
@@ -68,4 +68,6 @@ spec:
         {{ toYaml .Values.frontend.readinessProbe | nindent 10 }}
         livenessProbe:
         {{ toYaml .Values.frontend.livenessProbe | nindent 10 }}
+        resources:
+        {{- toYaml .Values.frontend.resources | nindent 10 }}
 {{- end }}

--- a/enterprise-edition/values.yaml
+++ b/enterprise-edition/values.yaml
@@ -236,6 +236,17 @@ doc:
   ##
   affinity: {}
 
+  ## doc resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 256Mi
+
 frontend:
   enabled: true
   replicas: 1
@@ -285,6 +296,17 @@ frontend:
   ## Pod affinity
   ##
   affinity: {}
+
+  ## frontend resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 256Mi
 
 
 utilityServer:


### PR DESCRIPTION
This PR Closes #21 

Changes :

- Resource variables are added and interpreted via the toYaml function (frontend & doc deployments)
- Some dashed were missing in the frontend deployment template adding white spaces in the generated yaml files

See the related issue for more details.